### PR TITLE
Fix tracking for auxiliary DIMACS variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.12)
 
 project(SMS VERSION "1.0" LANGUAGES C CXX)
 
+include(CTest)
+
 # set(CMAKE_EXE_LINKER_FLAGS "-static")
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -37,6 +39,16 @@ else ()
 endif()
 
 add_subdirectory(src)
+
+if(BUILD_TESTING)
+	add_test(
+		NAME dimacs_auxiliary_variables
+		COMMAND bash
+			"${PROJECT_SOURCE_DIR}/tests/check_dimacs_auxiliary_variables.sh"
+			"$<TARGET_FILE:smsg>"
+			"${PROJECT_SOURCE_DIR}/tests/dimacs_auxiliary_variables.cnf"
+	)
+endif()
 # add_subdirectory(src_directed)
 # add_subdirectory(src_hypher_graph)
 # add_subdirectory(src_hypher_graph_incidence)

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -169,7 +169,19 @@ GraphSolver *createSolver(SolverConfig &config, struct minimality_config_t &mini
     {
         int maxVar;
         solver->read_dimacs(dimacsFile.c_str(), maxVar);
+        int oldNumVars = solver->numVars;
         solver->numVars = std::max(solver->numVars, maxVar);
+        // Resize internal tracking structures BEFORE observing new vars so that
+        // notify_assignment never writes out-of-bounds.
+        solver->extendVarTracking(solver->numVars);
+        // Observe any new variables introduced by the DIMACS file so that
+        // notify_assignment is called on them and currentAssignment tracks them.
+        // This is essential when users add CNF auxiliary variables (e.g., for
+        // cardinality counters in color-symmetry breakers).
+        for (int v = oldNumVars + 1; v <= solver->numVars; v++)
+        {
+            solver->add_observed_var(v);
+        }
     }
 
     if (!config.cubeFileTest.empty())

--- a/src/sms.hpp
+++ b/src/sms.hpp
@@ -80,6 +80,14 @@ public:
 
   int sms_solve();                                                                     // TODO Same return values as CaDiCaL::solve but also takes fully defined graphs into account
   vector<vector<int>> getEdgeVariables() { return graphHandler->getEdgeVariables(); }; // returns the edge variables used for representing the graph
+  // Resize internal variable-tracking vectors to accommodate variables added externally
+  // (e.g., auxiliary variables from a user DIMACS file).
+  void extendVarTracking(int newMaxVar) {
+    if ((int)currentAssignment.size() <= newMaxVar)
+      currentAssignment.resize(newMaxVar + 1, truth_value_unknown);
+    if ((int)isFixed.size() <= newMaxVar)
+      isFixed.resize(newMaxVar + 1, false);
+  }
   void printStats();
   void generateCubes(int assignmentCutoff);
   void createGame(float randomize = 0, vector<int> assumptions = {}, int recLvl = 0); // print the trail on a conflict or if all clauses are satisfied using lookeahead

--- a/tests/check_dimacs_auxiliary_variables.sh
+++ b/tests/check_dimacs_auxiliary_variables.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+binary=$1
+instance=$2
+
+output=$("$binary" \
+    --vertices 2 \
+    --no-SMS \
+    --all-graphs \
+    --hide-graphs \
+    --dimacs "$instance" 2>&1)
+status=$?
+
+printf '%s\n' "$output"
+
+if [[ $status -ne 20 ]]; then
+    echo "expected SMS to exhaust the models (exit 20), got $status" >&2
+    exit 1
+fi
+
+if ! grep -q "Number of graphs: 2" <<<"$output"; then
+    echo "expected both assignments of the graph-edge variable" >&2
+    exit 1
+fi

--- a/tests/dimacs_auxiliary_variables.cnf
+++ b/tests/dimacs_auxiliary_variables.cnf
@@ -1,0 +1,3 @@
+c Auxiliary variable 2 is not a graph-edge variable when --vertices 2.
+p cnf 2 1
+2 0


### PR DESCRIPTION
## Summary

- resize SMS's assignment and fixed-variable tracking when a DIMACS file introduces variables beyond the graph-edge variables
- register those auxiliary variables with CaDiCaL's external-propagator observation API
- add a regression fixture that enumerates both assignments of the graph-edge variable while an auxiliary DIMACS variable is present

## Why

`read_dimacs` can raise the solver's maximum variable above the number allocated by `GraphHandler`. Those variables were not observed and the callback tracking vectors were not extended, so assignment notifications could index past the vectors and auxiliary assignments were not tracked consistently.

## Validation

- branch diff is one commit on current upstream `main`
- macOS/libc++ build passes with the existing upstream missing-standard-header issue neutralized (covered by the separate portability PR)
- `bash tests/check_dimacs_auxiliary_variables.sh build/src/smsg tests/dimacs_auxiliary_variables.cnf`
  - exits with SMS's expected exhaustion status
  - reports `Number of graphs: 2`
