### PR TITLE
Add guarded DRAT proof output for DIMACS solves

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,7 @@
 #include "useful.h"
+#include <cstdlib>
+#include <exception>
+#include <iostream>
 #include <boost/program_options.hpp>
 namespace po = boost::program_options;
 
@@ -12,14 +15,21 @@ int main(int argc, char const **argv)
 {
     clock_t start = clock();
 
-    po::variables_map vm;
-    GraphSolver *solver = parseOptions(argc, argv, vm);
+    try
+    {
+        po::variables_map vm;
+        GraphSolver *solver = parseOptions(argc, argv, vm);
 
-    // TODO parse arguments
-    int result = solver->sms_solve();
+        int result = solver->sms_solve();
 
-    delete solver;
+        delete solver;
 
-    printf("Total time: %f\n", ((double)clock() - start) / CLOCKS_PER_SEC);
-    return result;
+        printf("Total time: %f\n", ((double)clock() - start) / CLOCKS_PER_SEC);
+        return result;
+    }
+    catch (const std::exception &error)
+    {
+        std::cerr << "Error: " << error.what() << std::endl;
+        return EXIT_FAILURE;
+    }
 }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1,5 +1,7 @@
 #include "options.hpp"
 
+#include <stdexcept>
+
 po::options_description main_opts("Main options");
 po::options_description output_opts("Output options");
 po::options_description minimality_opts("Minimality checker options");
@@ -49,6 +51,7 @@ void initOptions(SolverConfig &config, struct minimality_config_t &minimalityCon
     
 
     other_opts.add_options()
+      ("proof", po::value<std::string>(&config.proofFile), "Write a DRAT proof for a pure-DIMACS decision solve (requires --dimacs and --no-SMS)")
       ("simplify", po::value<std::string>(&config.simplifiedFormulaFile), "Simplify the CNF formula and write it to the given file. (Directly after prerun)")
       ("learned-clauses", po::value<std::string>(&config.learnedClausesFile),"Write the learned clauses to the given file after prerun")
       ("max-learned-clause-size", po::value<int>(&config.maxPrintedLearnedClauseSize)->default_value(5), "The maximal size of the learned clauses that should be printed (also for `simplify`)")
@@ -162,6 +165,38 @@ void addPropagators(GraphSolver *solver, const propagators_config_t &propagators
 
 GraphSolver *createSolver(SolverConfig &config, struct minimality_config_t &minimalitConfig, propagators_config_t &propagatorsConfig, string dimacsFile)
 {
+    if (!config.proofFile.empty())
+    {
+        if (dimacsFile.empty())
+            throw std::invalid_argument("--proof requires a DIMACS input file");
+        if (!minimalitConfig.turnoffSMS)
+            throw std::invalid_argument(
+                "--proof requires --no-SMS: dynamic minimality clauses are not "
+                "part of the DIMACS formula checked by a standalone DRAT verifier");
+        if (propagatorsConfig.generate_connected || propagatorsConfig.planar ||
+            !propagatorsConfig.forbiddenSubgraphFile.empty() ||
+            !propagatorsConfig.forbiddenInducedSubgraphFile.empty() ||
+            propagatorsConfig.minChromaticNumber > 0 ||
+            propagatorsConfig.non010colorable ||
+            !propagatorsConfig.qcirFile.empty())
+            throw std::invalid_argument(
+                "--proof cannot be combined with graph-property propagators: "
+                "their semantic clauses are not part of the DIMACS formula "
+                "checked by a standalone DRAT verifier");
+        if (!config.lratFile.empty())
+            throw std::invalid_argument("--proof and --lrat-output cannot be used together");
+        if (config.allModels)
+            throw std::invalid_argument(
+                "--proof cannot be combined with --all-graphs: model-blocking "
+                "clauses would make the final proof certify an augmented formula");
+        if (config.assignmentCutoff || config.simpleAssignmentCutoff ||
+            config.createGame || !config.cubeFile.empty() ||
+            !config.cubeFileTest.empty())
+            throw std::invalid_argument(
+                "--proof supports a single decision solve only; cubing, game, "
+                "and cube-test modes alter the formula or solve under assumptions");
+    }
+
     GraphSolver *solver = new GraphSolver(config, minimalitConfig);
     solver->set("quiet", 1);
 

--- a/src/sms.cpp
+++ b/src/sms.cpp
@@ -9,6 +9,17 @@ GraphSolver::GraphSolver(SolverConfig config, struct minimality_config_t minimal
 {
   current_trail.push_back(vector<int>());
   this->vertices = config.vertices;
+
+  // Set up proof tracing BEFORE connecting propagator (CaDiCaL requires this order).
+  if (!config.proofFile.empty())
+  {
+    if (!this->trace_proof(config.proofFile.c_str()))
+    {
+      std::cerr << "Failed to open proof file for writing: " << config.proofFile << std::endl;
+      throw std::runtime_error("trace_proof failed");
+    }
+  }
+
   connect_external_propagator(this);
   connect_fixed_listener(this);
   graphHandler = new GraphHandler(vertices, config.directed);
@@ -307,6 +318,25 @@ int GraphSolver::sms_solve()
   printStats();
 
   LOG(LOG_LEVEL_INFO, "Result: " << res);
+
+  if (!config.proofFile.empty())
+  {
+    this->flush_proof_trace();
+    this->close_proof_trace();
+    if (res == 20)
+    {
+      LOG(LOG_LEVEL_INFO, "UNSAT DRAT proof written to: " << config.proofFile);
+    }
+    else
+    {
+      LOG(
+          LOG_LEVEL_WARNING,
+          "Proof trace written to " << config.proofFile
+                                    << "; it is not an UNSAT certificate because the result was "
+                                    << res);
+    }
+  }
+
   return res;
 }
 

--- a/src/sms.hpp
+++ b/src/sms.hpp
@@ -46,6 +46,8 @@ typedef struct
   int createGameRecLvl = 0; // the depth of the lookahead on the truth values for creating games
 
   vector<string> cadicalConfig; // space-separated list of command-line options for cadical without the -- prefixes
+
+  string proofFile; // if non-empty, write DRAT proof to this file
 } SolverConfig;
 
 typedef struct


### PR DESCRIPTION
## Summary

- add `--proof FILE` for CaDiCaL-native DRAT output
- start proof tracing before connecting the external propagator, as required by CaDiCaL
- flush and close the trace after the decision solve
- restrict the option to pure-DIMACS, single-decision, `--no-SMS` runs
- reject combinations whose dynamic clauses or assumptions would make the standalone proof certify a different formula

## Why

SMS already exposes DIMACS decision solving, but there was no guarded way to retain a standalone-checkable UNSAT certificate. Proof output is only sound for the original DIMACS formula when minimality, graph-property propagators, enumeration, cubing, and assumption-based modes are disabled.

## Validation

- branch diff is one commit on current upstream `main`
- macOS/libc++ build passes with the existing upstream missing-standard-header issue neutralized (covered by the separate portability PR)
- a two-clause UNSAT fixture returns status 20 and writes a DRAT trace
- `drat-trim` reports `s VERIFIED` for that formula and trace
- omitting `--no-SMS` is rejected with an explanatory error
